### PR TITLE
Add AppPrioritiser view

### DIFF
--- a/src/AppPrioritiser.jsx
+++ b/src/AppPrioritiser.jsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect, useRef } from "react";
+import { fetchImpactEffort, setImpactEffort } from "./api";
+
+const AppPrioritiser = () => {
+  const [rowData, setRowData] = useState([]);
+  const [positions, setPositions] = useState({});
+  const [collapsed, setCollapsed] = useState(true);
+  const containerRef = useRef(null);
+  const draggingRef = useRef(null);
+
+  // Listen for filtered rows from AppGrid
+  useEffect(() => {
+    const channel = new BroadcastChannel("tagSelectChannel");
+    channel.onmessage = (event) => {
+      const { tagFilter } = event.data;
+      setRowData(tagFilter || []);
+    };
+    return () => channel.close();
+  }, []);
+
+  // Load impact/effort values whenever rowData changes
+  useEffect(() => {
+    if (rowData.length === 0) return;
+    const ids = rowData.map((c) => c.id);
+    fetchImpactEffort(ids).then((data) => {
+      const newPos = {};
+      ids.forEach((id) => {
+        if (data && data[id]) newPos[id] = data[id];
+        else newPos[id] = { impact: 50, effort: 50 };
+      });
+      setPositions(newPos);
+    });
+  }, [rowData]);
+
+  const handleMouseDown = (e, id) => {
+    draggingRef.current = id;
+    e.stopPropagation();
+  };
+
+  const handleMouseMove = (e) => {
+    if (!draggingRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const effort = ((e.clientX - rect.left) / rect.width) * 100;
+    const impact = (1 - (e.clientY - rect.top) / rect.height) * 100;
+    setPositions((prev) => ({
+      ...prev,
+      [draggingRef.current]: {
+        impact: Math.min(100, Math.max(0, impact)),
+        effort: Math.min(100, Math.max(0, effort)),
+      },
+    }));
+  };
+
+  const handleMouseUp = () => {
+    const id = draggingRef.current;
+    if (id) {
+      const { impact, effort } = positions[id] || { impact: 50, effort: 50 };
+      setImpactEffort(id, impact, effort);
+    }
+    draggingRef.current = null;
+  };
+
+  return (
+    <div className="bg-white rounded shadow">
+      <div className="flex justify-between items-center bg-white text-black px-4 py-2 cursor-pointer select-none">
+        <span className="font-semibold">App Prioritiser</span>
+        <button
+          className="text-lg font-bold"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? "Expand prioritiser" : "Collapse prioritiser"}
+        >
+          {collapsed ? "▼" : "▲"}
+        </button>
+      </div>
+      <div
+        className={`transition-all duration-300 overflow-hidden`}
+        style={{ height: collapsed ? 0 : 400 }}
+      >
+        <div
+          ref={containerRef}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          className="relative h-96 border m-4 select-none"
+        >
+          <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-300" />
+          <div className="absolute top-1/2 left-0 right-0 h-px bg-gray-300" />
+          {rowData.map((container) => {
+            const pos = positions[container.id] || { impact: 50, effort: 50 };
+            return (
+              <div
+                key={container.id}
+                onMouseDown={(e) => handleMouseDown(e, container.id)}
+                style={{
+                  position: "absolute",
+                  left: `${pos.effort}%`,
+                  top: `${100 - pos.impact}%`,
+                  transform: "translate(-50%, -50%)",
+                }}
+                className="cursor-pointer bg-blue-100 text-xs px-2 py-1 rounded shadow"
+                title={`${container.Name} (Impact ${Math.round(pos.impact)}, Effort ${Math.round(pos.effort)})`}
+              >
+                {container.Name}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AppPrioritiser;

--- a/src/api.js
+++ b/src/api.js
@@ -437,3 +437,29 @@ export const createContainersFromContent = async (prompt, content) => {
         throw error; // Re-throw to let the modal handle the error display
     }
 };
+
+export const fetchImpactEffort = async (containerIds) => {
+    try {
+        const response = await apiClient.post(`${getApiUrl()}/get_impact_effort`, {
+            container_ids: containerIds,
+        });
+        return response.data; // {id: {impact: number, effort: number}}
+    } catch (error) {
+        console.error("Error fetching impact/effort:", error);
+        return {};
+    }
+};
+
+export const setImpactEffort = async (id, impact, effort) => {
+    try {
+        const response = await apiClient.post(`${getApiUrl()}/set_impact_effort`, {
+            id,
+            impact,
+            effort,
+        });
+        return response.data;
+    } catch (error) {
+        console.error("Error setting impact/effort:", error);
+        return null;
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import AppGrid from './AppGrid';
 import AppFlow from './AppFlow';
 import AppMermaid from './AppMermaid';
 import AppMatrix from './AppMatrix';
+import AppPrioritiser from './AppPrioritiser';
 import CreateFromContentModal from './CreateFromContentModal';
 import reportWebVitals from './reportWebVitals';
 
@@ -96,6 +97,10 @@ const App = () => {
 
         <section id="matrix">
           <AppMatrix />
+        </section>
+
+        <section id="prioritiser">
+          <AppPrioritiser />
         </section>
 
         <section id="sub">


### PR DESCRIPTION
## Summary
- implement `AppPrioritiser` component
- hook into broadcast channel to fetch filtered containers
- store impact/effort values via new API helpers
- mount the prioritiser view in the main app

## Testing
- `yarn test --watchAll=false` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686632affaf8832584b7c382016fff15