### PR TITLE
Use context instead of broadcast for filtered rows

### DIFF
--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,0 +1,17 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AppContext = createContext();
+
+export const AppProvider = ({ children }) => {
+  const [rows, setRows] = useState([]);
+
+  return (
+    <AppContext.Provider value={{ rows, setRows }}>
+      {children}
+    </AppContext.Provider>
+  );
+};
+
+export const useAppContext = () => useContext(AppContext);
+
+export default AppContext;

--- a/src/AppGrid.js
+++ b/src/AppGrid.js
@@ -1,5 +1,6 @@
 // React imports
 import React, { useState, useRef, useEffect } from "react";
+import { useAppContext } from "./AppContext";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry } from "ag-grid-community";
 import { createNewRow } from "./ModalNewContainer"; // Import the function to create a new row
@@ -13,7 +14,7 @@ import columnDefs from "./gridColumnDefs";
 import { fetchContainers, fetchChildren, saveContainers, fetchContainerById } from "./api";
 import {
   useFetchData, useWriteBackButton, useAddRowButton, useLoadButtonEffect, useImportButtonEffect,
-  useSaveButtonEffect, useDropDownEffect, useLoadDataEffect, useFilteredRowBroadcast,
+  useSaveButtonEffect, useDropDownEffect, useLoadDataEffect, useFilteredRowContext,
   useClearButtonEffect, useRowSelectMessage, flashAndScrollToRow, useAddChildChannel, useRequestReloadChannel, useRekeyButtonEffect, useAddTagsChannel, useRemoveTagsChannel
 } from "./gridEffects";
 import { handleWriteBack } from "./effectsShared";
@@ -29,7 +30,7 @@ import { AllCommunityModule } from "ag-grid-community";
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 const App = () => {
-  const [rowData, setRowData] = useState([]); // State to hold fetched data
+  const { rows: rowData, setRows: setRowData } = useAppContext();
   // const [miniMapData, setMiniMapData] = useState([]); // Mini-map children data
   // const [lastSelectedRow, setLastSelectedRow] = useState(null); // Last selected row
   const [isLoadModalOpen, setLoadModalOpen] = useState(false); // State for load modal
@@ -177,14 +178,8 @@ const App = () => {
       }
     }
 
-    // console.log('Filtered rows:', filteredRowData);
-
-    // Create BroadcastChannel
-    const channel = new BroadcastChannel('tagSelectChannel');
-    // Send message
-    channel.postMessage({ tagFilter: filteredRowData });
-    // Close the channel
-    channel.close();
+    // Update context with filtered rows
+    setRowData(filteredRowData);
   }
 
   // OnFilter
@@ -271,7 +266,7 @@ const App = () => {
   useFetchData(setRowData, fetchContainers);
   useWriteBackButton(rowData);
   useLoadDataEffect(setRowData, fetchContainers, sendFilteredRows);
-  useFilteredRowBroadcast(rowData, sendFilteredRows);
+  useFilteredRowContext(rowData, sendFilteredRows);
   useAddRowButton(handleAddRow);
   useLoadButtonEffect(setLoadModalOpen, setMerge);
   useImportButtonEffect(setLoadModalOpen, setMerge);

--- a/src/AppMatrix.jsx
+++ b/src/AppMatrix.jsx
@@ -1,24 +1,15 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { manyChildren, setPosition } from "./api";
+import { useAppContext } from "./AppContext";
 
 const AppMatrix = () => {
-  const [rowData, setRowData] = useState([]);
+  const { rows: rowData } = useAppContext();
   const [relationships, setRelationships] = useState({});
   const [loading, setLoading] = useState(false);
   const [editingCell, setEditingCell] = useState(null);
   const [collapsed, setCollapsed] = useState(true);
   const [hideEmpty, setHideEmpty] = useState(true); // New state for hiding empty rows/columns
   const inputRef = useRef(null);
-
-  // Listen for row data updates from other components
-  useEffect(() => {
-    const channel = new BroadcastChannel("tagSelectChannel");
-    channel.onmessage = (event) => {
-      const { tagFilter } = event.data;
-      setRowData(tagFilter || []);
-    };
-    return () => channel.close();
-  }, []);
 
   // Use manyChildren to get all relationships efficiently
   const loadRelationships = useCallback(async () => {

--- a/src/AppPrioritiser.jsx
+++ b/src/AppPrioritiser.jsx
@@ -1,21 +1,12 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useAppContext } from "./AppContext";
 
 const AppPrioritiser = () => {
-  const [rowData, setRowData] = useState([]);
+  const { rows: rowData, setRows: setRowData } = useAppContext();
   const [positions, setPositions] = useState({});
   const [collapsed, setCollapsed] = useState(true);
   const containerRef = useRef(null);
   const draggingRef = useRef(null);
-
-  // Listen for filtered rows from AppGrid
-  useEffect(() => {
-    const channel = new BroadcastChannel("tagSelectChannel");
-    channel.onmessage = (event) => {
-      const { tagFilter } = event.data;
-      setRowData(tagFilter || []);
-    };
-    return () => channel.close();
-  }, []);
 
   // Initialize positions from rowData's built-in Impact/Effort fields
   useEffect(() => {

--- a/src/flowEffects.js
+++ b/src/flowEffects.js
@@ -1,5 +1,6 @@
 
 import { useEffect, useCallback, useRef } from 'react';
+import { useAppContext } from './AppContext';
 import { applyEdgeChanges, } from '@xyflow/react';
 import { setPosition } from './api';
 import { createNewRow } from './ModalNewContainer';
@@ -310,6 +311,7 @@ export const useCreateNodesAndEdges = (params) => {
 
 
 export const useTagsChange = (rowData, setRowData, keepLayout) => {
+    const { rows: tagFilter } = useAppContext();
     const rowDataRef = useRef(rowData);
 
     // Keep ref updated
@@ -318,35 +320,19 @@ export const useTagsChange = (rowData, setRowData, keepLayout) => {
     }, [rowData]);
 
     useEffect(() => {
-        const channel = new BroadcastChannel('tagSelectChannel');
-
-        channel.onmessage = (event) => {
-            const { tagFilter } = event.data;
-            console.log('Tag filter changed:');
-            console.log("Keep node setting:", keepLayout);
-            const keepLayoutetting = keepLayout;
-            var filteredTagFilter = [];
-            if (keepLayoutetting) {
-                // Remove rows from tagFilter that are not in rowDataRef
-                filteredTagFilter = tagFilter.filter((row) =>
-                    rowDataRef.current.some((r) => r.id === row.id)
-                );
-
-            }
-            else {
-                // Keep all rows in tagFilter
-                filteredTagFilter = tagFilter;
-                console.log('Keeping all rows in tagFilter');
-            }
-            setRowData(filteredTagFilter);
-            console.log('Row data at time of event (outdated)');
-        };
-
-        return () => {
-            channel.close();
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        console.log('Tag filter changed:');
+        console.log("Keep node setting:", keepLayout);
+        let filteredTagFilter = [];
+        if (keepLayout) {
+            filteredTagFilter = tagFilter.filter((row) =>
+                rowDataRef.current.some((r) => r.id === row.id)
+            );
+        } else {
+            filteredTagFilter = tagFilter;
+            console.log('Keeping all rows in tagFilter');
+        }
+        setRowData(filteredTagFilter);
+    }, [tagFilter, keepLayout, setRowData]);
 };
 
 

--- a/src/gridEffects.js
+++ b/src/gridEffects.js
@@ -185,15 +185,8 @@ export const useLoadDataEffect = (setRowData, fetchContainers, sendFilteredRows)
     }, [setRowData, fetchContainers, sendFilteredRows]);
 };
 
-export const useFilteredRowBroadcast = (rowData, sendFilteredRows) => {
+export const useFilteredRowContext = (rowData, sendFilteredRows) => {
     const prevCountRef = useRef(rowData.length);
-
-    const handleRequestRefresh = useCallback(() => {
-        console.log("Received requestRefresh message:");
-        sendFilteredRows();
-    }, [sendFilteredRows]);
-
-    useBroadcastChannel('requestRefreshChannel', handleRequestRefresh, [handleRequestRefresh]);
 
     useEffect(() => {
         const refreshButton = document.getElementById("refreshButton");
@@ -203,7 +196,7 @@ export const useFilteredRowBroadcast = (rowData, sendFilteredRows) => {
             refreshButton.addEventListener("click", handleRefreshClick);
         }
 
-        // Only broadcast when row count actually changes
+        // Update when row count changes
         if (rowData.length !== prevCountRef.current) {
             sendFilteredRows();
             prevCountRef.current = rowData.length;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { AppProvider } from './AppContext';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import AppGrid from './AppGrid';
@@ -135,7 +136,9 @@ const App = () => {
 const root = ReactDOM.createRoot(document.getElementById('app'));
 root.render(
   <React.StrictMode>
-    <App />
+    <AppProvider>
+      <App />
+    </AppProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add `AppContext` for sharing filtered row data
- wrap the app in `AppProvider`
- push filtered rows to context instead of broadcast
- read filtered rows from context in matrix and prioritiser
- update flow hooks to use context

## Testing
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68663fd0465083258ed6c57a53d5641e