### PR TITLE
Fix layer reload and share rows

### DIFF
--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { requestReloadChannel } from './effectsShared';
 
 const AppContext = createContext();
 
@@ -24,6 +25,7 @@ export const AppProvider = ({ children }) => {
   const removeLayer = (layer) => {
     setLayerOptions((prev) => prev.filter((l) => l !== layer));
     setActiveLayers((prev) => prev.filter((l) => l !== layer));
+    requestReloadChannel();
   };
 
   const toggleLayer = (layer) => {
@@ -32,6 +34,7 @@ export const AppProvider = ({ children }) => {
         ? prev.filter((l) => l !== layer)
         : [...prev, layer]
     );
+    requestReloadChannel();
   };
 
   const value = {

--- a/src/AppFlow.js
+++ b/src/AppFlow.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
+import { useAppContext } from './AppContext';
 import {
   ReactFlow, ReactFlowProvider // This is the provider component linked to Zustand store
   , MiniMap, Controls, Background, useNodesState, useEdgesState, useReactFlow, addEdge, ControlButton
@@ -22,7 +23,7 @@ const App = ({ keepLayout, setKeepLayout }) => {
 
   // Step 2: Zustand store for nodes and edges ---
   const flowWrapperRef = React.useRef(null);
-  const [rowData, setRowData] = useState([]);
+  const { rows: rowData, setRows: setRowData } = useAppContext();
   const [layoutPositions, setLayoutPositions] = useState({});
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges] = useEdgesState();


### PR DESCRIPTION
## Summary
- broadcast reload when layers change
- use shared row data in AppFlow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b92a7c10883259710a82fdb634e0c