### PR TITLE
Fix setRowData loop

### DIFF
--- a/src/flowEffects.js
+++ b/src/flowEffects.js
@@ -335,7 +335,14 @@ export const useTagsChange = (rowData, setRowData, keepLayout) => {
             console.log('Keeping all rows in tagFilter');
         }
         filteredTagFilter = filteredTagFilter.filter(r => rowInLayers(r, activeLayers));
-        setRowData(filteredTagFilter);
+
+        const currentRows = rowDataRef.current;
+        const isSameLength = filteredTagFilter.length === currentRows.length;
+        const isSameIds = isSameLength && filteredTagFilter.every((row, idx) => row.id === currentRows[idx].id);
+
+        if (!isSameIds) {
+            setRowData(filteredTagFilter);
+        }
     }, [tagFilter, keepLayout, setRowData, activeLayers]);
 };
 


### PR DESCRIPTION
## Summary
- ensure `useTagsChange` updates row data only when needed

## Testing
- `npm start` *(fails: none)*

------
https://chatgpt.com/codex/tasks/task_e_687be5cc802c8325b95a558df5ba087c