### PR TITLE
Fix duplicate rows when adding/removing tags

### DIFF
--- a/src/gridEffects.js
+++ b/src/gridEffects.js
@@ -233,7 +233,10 @@ export const useAddTagsChannel = (gridApiRef, setRowData) => {
             const selectedNodes = selectedIds.map(id => gridApiRef.current.getRowNode(id));
             addTagToNodes(selectedNodes, tags, gridApiRef.current);
             setRowData((prev) => {
-                const updated = [...prev, ...selectedNodes.map(node => node.data)];
+                const updated = prev.map(row => {
+                    const node = selectedNodes.find(n => n.data.id === row.id);
+                    return node ? { ...row, ...node.data } : row;
+                });
                 writeBackData(updated);
                 return updated;
             });
@@ -255,7 +258,10 @@ export const useRemoveTagsChannel = (gridApiRef, setRowData) => {
             const selectedNodes = selectedIds.map(id => gridApiRef.current.getRowNode(id));
             removeTagFromNodes(selectedNodes, tags, gridApiRef.current);
             setRowData((prev) => {
-                const updated = [...prev, ...selectedNodes.map(node => node.data)];
+                const updated = prev.map(row => {
+                    const node = selectedNodes.find(n => n.data.id === row.id);
+                    return node ? { ...row, ...node.data } : row;
+                });
                 writeBackData(updated);
                 return updated;
             });


### PR DESCRIPTION
## Summary
- update `useAddTagsChannel` and `useRemoveTagsChannel` to update rows in place

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688682470dd883259b29cec6e37c4e84