### PR TITLE
Encode state names in API endpoints

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -563,7 +563,9 @@ export const createContainersFromContent = async (prompt, content) => {
 export const switchState = async (newState) => {
     try {
         console.log("Switching to state:", newState);
-        const response = await apiClient.get(`${getApiUrl()}/switch_state/${newState}`);
+        const response = await apiClient.get(
+            `${getApiUrl()}/switch_state/${encodeURIComponent(newState)}`
+        );
         // broadcast refresh request
         requestRefreshChannel();
         return response.data;
@@ -577,7 +579,9 @@ export const switchState = async (newState) => {
 export const removeState = async (stateName) => {
     try {
         console.log("Removing state:", stateName);
-        const response = await apiClient.get(`${getApiUrl()}/remove_state/${stateName}`);
+        const response = await apiClient.get(
+            `${getApiUrl()}/remove_state/${encodeURIComponent(stateName)}`
+        );
         return response.data;
     } catch (error) {
         console.error("Error removing state:", error);


### PR DESCRIPTION
## Summary
- URL-encode state names for switch/remove state API calls to support spaces and symbols.

## Testing
- `node - <<'NODE'
const getApiUrl = () => 'https://example.com';
const apiClient = { get: (url) => { console.log('Requested URL:', url); return Promise.resolve({data:{}}); } };
async function switchState(newState) {
  console.log('Switching to state:', newState);
  const response = await apiClient.get(`${getApiUrl()}/switch_state/${encodeURIComponent(newState)}`);
  return response.data;
}
async function removeState(stateName) {
  console.log('Removing state:', stateName);
  const response = await apiClient.get(`${getApiUrl()}/remove_state/${encodeURIComponent(stateName)}`);
  return response.data;
}
(async () => {
  await switchState('my state? test');
  await removeState('my state? test');
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6890f129d2788325bc59680412c3eb5f