### PR TITLE
Ensure AppMatrix context menu works after filtering

### DIFF
--- a/src/AppMatrix.js
+++ b/src/AppMatrix.js
@@ -342,8 +342,8 @@ const AppMatrix = () => {
                             // Find the actual edge from the edges array
                             const edge = edges.find(
                               (e) =>
-                                e.source === (flipped ? targetContainer.id : sourceContainer.id) &&
-                                e.target === (flipped ? sourceContainer.id : targetContainer.id)
+                                e.source === String(flipped ? targetContainer.id : sourceContainer.id) &&
+                                e.target === String(flipped ? sourceContainer.id : targetContainer.id)
                             );
 
                             return (

--- a/src/components/MatrixCell.jsx
+++ b/src/components/MatrixCell.jsx
@@ -32,8 +32,8 @@ const MatrixCell = ({
 
   const edge = edges.find(
     (e) =>
-      e.source === (flipped ? targetContainer.id : sourceContainer.id) &&
-      e.target === (flipped ? sourceContainer.id : targetContainer.id)
+      e.source === String(flipped ? targetContainer.id : sourceContainer.id) &&
+      e.target === String(flipped ? sourceContainer.id : targetContainer.id)
   );
 
   return (


### PR DESCRIPTION
## Summary
- Normalize container IDs to strings when matching edges so matrix right-click menus appear reliably
- Apply the same fix to MatrixCell component for consistency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689397c00bf88325b3ee1661527305cd