### PR TITLE
Fix custom edge tooltip and use full label for renaming

### DIFF
--- a/src/hooks/customEdge.js
+++ b/src/hooks/customEdge.js
@@ -137,7 +137,7 @@ const CustomEdge = ({
         }
         if (typeof onEdgeDoubleClick === 'function') {
             // Pass the event and edge object (mimic ReactFlow's signature)
-            onEdgeDoubleClick(e, { id, source, target, label: data?.label });
+            onEdgeDoubleClick(e, { id, source, target, label: data?.fullLabel ?? data?.label });
         }
     };
 
@@ -161,7 +161,6 @@ const CustomEdge = ({
                     x={labelX - 60}
                     y={labelY - 20}
                     requiredExtensions="http://www.w3.org/1999/xhtml"
-                    style={{ pointerEvents: 'none' }}
                 >
                     <div
                         ref={labelRef}
@@ -170,6 +169,7 @@ const CustomEdge = ({
                         onMouseLeave={handleMouseLeave}
                         onClick={handleLabelClick}
                         onDoubleClick={handleLabelDoubleClick}
+                        title={data?.description}
                         style={{
                             pointerEvents: 'auto',
                             background: '#f9fafb',
@@ -194,7 +194,7 @@ const CustomEdge = ({
 
             {hovered && data?.description && (
                 <Tooltip x={tooltipPos.x} y={tooltipPos.y}>
-                    {data.description}HELLO
+                    {data.description}
                 </Tooltip>
             )}
         </>

--- a/src/hooks/flowBuildVisibleEdges.js
+++ b/src/hooks/flowBuildVisibleEdges.js
@@ -59,12 +59,13 @@ export function buildVisibleEdges(params) {
                     let data;
                     // console.log('DEBUG EDGE POSITION:', c.position);
                     if (c.position !== null && typeof c.position === 'object' && c.position.label) {
-                        const label = c.position.label.length > 20
-                            ? c.position.label.substring(0, 20) + '...'
-                            : c.position.label;
-                        data = { label: label, description: c.position.description };
+                        const fullLabel = c.position.label;
+                        const label = fullLabel.length > 20
+                            ? fullLabel.substring(0, 20) + '...'
+                            : fullLabel;
+                        data = { label: label, fullLabel: fullLabel, description: c.position.description };
                     } else {
-                        data = { label: "" };
+                        data = { label: "", fullLabel: "" };
                     }
 
                     // assemble edge object

--- a/src/hooks/flowEffects.js
+++ b/src/hooks/flowEffects.js
@@ -285,13 +285,16 @@ export const useOnEdgeDoubleClick = (setEdges) => {
             const sourceId = edge.source;
             const targetId = edge.target;
             // Open an input dialog to edit the edge label
-            const newLabel = window.prompt('Enter new label:', edge.label || '');
+            const currentLabel = edge.label ?? edge.data?.fullLabel ?? edge.data?.label ?? '';
+            const newLabel = window.prompt('Enter new label:', currentLabel);
             if (newLabel !== null) {
                 // Update the edge label in the state
                 setEdges((eds) =>
                     eds.map((e) => {
                         if (e.id === edge.id) {
-                            return { ...e, label: newLabel };
+                            const fullLabel = newLabel;
+                            const label = fullLabel.length > 20 ? fullLabel.substring(0, 20) + '...' : fullLabel;
+                            return { ...e, data: { ...e.data, label, fullLabel } };
                         }
                         return e;
                     })


### PR DESCRIPTION
## Summary
- show edge descriptions on hover by wiring up tooltip and `title`
- preserve full edge label so renaming prefills complete text
- update rename logic to maintain both full and truncated labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894dc12c3188325b1f06503213520ac