### PR TITLE
Clear layers on data load

### DIFF
--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -138,6 +138,11 @@ export const AppProvider = ({ children }) => {
     requestRefreshChannel();
   };
 
+  const clearLayers = () => {
+    setLayerOptions([]);
+    setActiveLayers([]);
+  };
+
   const value = {
     rowData,
     setRowData,
@@ -149,6 +154,7 @@ export const AppProvider = ({ children }) => {
     activeLayers,
     setActiveLayers,
     toggleLayer,
+    clearLayers,
     nodes,
     setNodes,
     edges,

--- a/src/AppGrid.js
+++ b/src/AppGrid.js
@@ -31,7 +31,7 @@ import { AllCommunityModule } from "ag-grid-community";
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 const App = () => {
-  const { rowData, setRowData, activeLayers, layerOptions } = useAppContext();
+  const { rowData, setRowData, activeLayers, layerOptions, clearLayers } = useAppContext();
   const displayRows = useMemo(
     () => rowData.filter((r) => rowInLayers(r, activeLayers)),
     [rowData, activeLayers]
@@ -243,7 +243,7 @@ const App = () => {
   // useModalButtonEffect(setModalOpen); // Pass modal state updater to the hook
   useRowSelectMessage(rowData, setRowData, gridApiRef);
   useAddChildChannel(gridApiRef, setRowData);
-  useRequestRefreshChannel(setRowData);
+  useRequestRefreshChannel(setRowData, clearLayers);
   useRekeyButtonEffect()
   useDedupButtonEffect()
   useAddTagsChannel(gridApiRef, setRowData);

--- a/src/components/ModalLoad.js
+++ b/src/components/ModalLoad.js
@@ -8,7 +8,7 @@ Modal.setAppElement("#app");
 const LoadModal = ({ isOpen, setIsOpen, setRowData, gridApiRef, setCurrentContainer, merge }) => {
     const [list, setList] = useState([]);
 
-    const { setLastLoadedFile } = useAppContext();
+    const { setLastLoadedFile, clearLayers } = useAppContext();
 
     const closeModal = () => {
         setIsOpen(false);
@@ -25,6 +25,7 @@ const LoadModal = ({ isOpen, setIsOpen, setRowData, gridApiRef, setCurrentContai
             await loadContainers(item);
         }
         setLastLoadedFile(item);
+        clearLayers();
 
         const channel = new BroadcastChannel('requestRefreshChannel');
         channel.postMessage({ type: "reload" });

--- a/src/hooks/gridEffects.js
+++ b/src/hooks/gridEffects.js
@@ -154,7 +154,7 @@ export const useDropDownEffect = () => {
 
 // Effect to load data from the server and attach listener to loadDataButton
 export const useReloadEffect = () => {
-    const { lastLoadedFile } = useAppContext();
+    const { lastLoadedFile, clearLayers } = useAppContext();
     useEffect(() => {
         console.log("Using ReLoad loadDataButton effect...");
         const loadDataButton = document.getElementById("loadDataButton");
@@ -164,6 +164,7 @@ export const useReloadEffect = () => {
             loadContainers(lastLoadedFile).then((data) => {
                 console.log("Loaded data:", data);
             });
+            clearLayers();
             // Broadcast a message to requestRefreshChannel
             setTimeout(() => {
                 const channel = new BroadcastChannel('requestRefreshChannel');
@@ -180,7 +181,7 @@ export const useReloadEffect = () => {
                 loadDataButton.removeEventListener("click", handleLoadData);
             }
         };
-    }, [lastLoadedFile]);
+    }, [lastLoadedFile, clearLayers]);
 };
 
 export const useRefreshEffect = (rowData, setRowData, fetchContainers, sendFilteredRows) => {
@@ -292,19 +293,22 @@ export const useRemoveTagsChannel = (gridApiRef, setRowData) => {
     useBroadcastChannel('removeTagsChannel', handleRemoveTags, [handleRemoveTags]);
 };
 
-export const useRequestRefreshChannel = (setRowData) => {
+export const useRequestRefreshChannel = (setRowData, clearLayers) => {
     useEffect(() => {
         const channel = new BroadcastChannel('requestRefreshChannel');
 
         channel.onmessage = async (event) => {
             console.log("Received requestRefresh message:", event.data);
+            if (event.data?.type === 'reload' || event.data?.type === 'refresh') {
+                clearLayers();
+            }
             asyncDataLoaderWithDateFormatting(fetchContainers, setRowData)();
         };
 
         return () => {
             channel.close();
         };
-    }, [setRowData]);
+    }, [setRowData, clearLayers]);
 }
 
 export const useRekeyButtonEffect = () => {


### PR DESCRIPTION
## Summary
- reset layer state with new `clearLayers` function in AppContext
- clear layers when loading containers and reloading data
- refresh hook rebuilds layer options after load actions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3534672c4832595c2eb84fd6122b7