### PR TITLE
Avoid artificial delay in graph layout

### DIFF
--- a/src/hooks/flowEffects.js
+++ b/src/hooks/flowEffects.js
@@ -365,14 +365,16 @@ export const useCreateNodesAndEdges = (params) => {
 
         const filtered = rowData.filter(r => rowInLayers(r, activeLayers));
         console.log("Generating nodes and edges with filtered rows:", filtered.length);
-        generateNodesAndEdges({
-            ...params,
-            rowData: filtered,
-            stateScores,
-            getHighestScoringContainer,
-            parentChildMap,
-            setParentChildMap
-        });
+        (async () => {
+            await generateNodesAndEdges({
+                ...params,
+                rowData: filtered,
+                stateScores,
+                getHighestScoringContainer,
+                parentChildMap,
+                setParentChildMap
+            });
+        })();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         // Only include values that should trigger regeneration

--- a/src/hooks/flowFetchAndCreateEdges.js
+++ b/src/hooks/flowFetchAndCreateEdges.js
@@ -8,7 +8,6 @@ export const fetchAndCreateEdges = async (computedNodes, params) => {
     const originalIdSet = new Set(computedNodes.map(n => n.id));
 
     // Fetch parent→children relationships
-    await new Promise(res => setTimeout(res, 500)); // Artificial delay for testing
     if (!parentChildMap) return;
 
     // Filter parentChildMap by originalIDSet

--- a/src/hooks/flowGenerateGraph.js
+++ b/src/hooks/flowGenerateGraph.js
@@ -2,12 +2,11 @@ import { fetchAndCreateEdges } from './flowFetchAndCreateEdges';
 import { fitViewToFlow } from './flowFunctions';
 export const GROUP_NODE_WIDTH = 300;
 
-export function generateNodesAndEdges(params) {
-    const { 
-        rowData, 
-        setNodes, 
-        stateScores, 
-        getHighestScoringContainer 
+export async function generateNodesAndEdges(params) {
+    const {
+        rowData,
+        stateScores,
+        getHighestScoringContainer
     } = params;
     
     if (!rowData || rowData.length === 0) return;
@@ -56,9 +55,8 @@ export function generateNodesAndEdges(params) {
         };
     });
 
-    fetchAndCreateEdges(computedNodes, params);
+    await fetchAndCreateEdges(computedNodes, params);
     fitViewToFlow();
-    setNodes(computedNodes);
 }
 
 


### PR DESCRIPTION
## Summary
- remove placeholder timeout in `fetchAndCreateEdges`
- make graph generation await edge creation before fitting view
- update hook to call generator asynchronously

## Testing
- `npm run build` *(fails: process hung during "Creating an optimized production build...")*


------
https://chatgpt.com/codex/tasks/task_e_68a9d668b61483259d0a946fe706d7f9