### PR TITLE
refactor: improve subflow group nodes

### DIFF
--- a/src/hooks/flowGroupNodes.js
+++ b/src/hooks/flowGroupNodes.js
@@ -1,32 +1,34 @@
-import React, { useState } from 'react'
-import { Handle, useNodeId } from '@xyflow/react'
-import { GROUP_NODE_WIDTH } from './flowGenerateGraph'
+import React from 'react';
+import { Handle, NodeResizer, useNodeId } from '@xyflow/react';
 
+/**
+ * Simple visual representation of a group/subflow node.
+ * - Shows a label and child count.
+ * - Provides handles for incoming/outgoing edges.
+ * - Includes a resizer so the subflow can be resized in the canvas.
+ */
 const GroupNode = ({ data, selected }) => {
-  const [hoveredHandle, setHoveredHandle] = useState(null)
-  const [isHovered, setIsHovered] = useState(false)
-  const nodeId = useNodeId()
-  const { Name, Description, children = [] } = data
+  const nodeId = useNodeId();
+  const { Name, children = [] } = data;
 
-  const bgColor = selected ? 'bg-blue-200' : 'bg-blue-100'
+  const bgColor = selected ? 'bg-blue-200' : 'bg-blue-100';
 
   return (
-    <div
-      className="w-full h-full relative"
-      style={{
-        width: '100%',
-        height: '100%',
-        padding: 0,
-        boxSizing: 'border-box',
-        overflow: 'visible',
-      }}
-    >
+    <div className="w-full h-full relative">
+      {/* Allows the group to be resized by the user */}
+      <NodeResizer
+        color="#94a3b8"
+        isVisible={selected}
+        minWidth={200}
+        minHeight={120}
+      />
+
       {/* Inner wrapper for rounded background and content */}
       <div
         className={`rounded-xl shadow-md ${bgColor} transition-all duration-150`}
         style={{
-          width: 'calc(100% - 8px)',   // 4px margin on each side
-          height: 'calc(100% - 8px)',  // 4px margin on each side
+          width: 'calc(100% - 8px)', // 4px margin on each side
+          height: 'calc(100% - 8px)',
           margin: '4px',
           display: 'flex',
           flexDirection: 'column',
@@ -37,18 +39,12 @@ const GroupNode = ({ data, selected }) => {
       >
         {/* Group label */}
         <div className="font-semibold text-base text-gray-800 mb-1 truncate">{Name}</div>
-        {Description && isHovered && (
-          <div className="absolute z-10 left-1/2 top-full mt-2 px-3 py-1 rounded bg-gray-900 text-white text-xs shadow"
-            style={{ transform: 'translateX(-50%)' }}>
-            {Description}
-          </div>
-        )}
         <div className="mt-auto text-xs text-gray-500">
           {children.length > 0 ? `${children.length} item${children.length > 1 ? 's' : ''}` : ''}
         </div>
       </div>
 
-      {/* Handles */}
+      {/* Handles for connecting to other nodes */}
       <Handle
         type="target"
         position="left"
@@ -64,8 +60,6 @@ const GroupNode = ({ data, selected }) => {
           opacity: 0.7,
           zIndex: 2,
         }}
-        onMouseEnter={() => setHoveredHandle('in')}
-        onMouseLeave={() => setHoveredHandle(null)}
       />
       <Handle
         type="source"
@@ -82,11 +76,9 @@ const GroupNode = ({ data, selected }) => {
           opacity: 0.7,
           zIndex: 2,
         }}
-        onMouseEnter={() => setHoveredHandle('out')}
-        onMouseLeave={() => setHoveredHandle(null)}
       />
     </div>
-  )
-}
+  );
+};
 
-export default GroupNode
+export default GroupNode;

--- a/src/hooks/flowLayouter.js
+++ b/src/hooks/flowLayouter.js
@@ -7,6 +7,33 @@ function estimateNodeHeight(label, width, fontSize = 16, paddingY = 16) {
     return Math.max(48, lines * lineHeight + paddingY);
 }
 
+// Run dagre on a subset of nodes/edges and return nodes with updated positions
+function layoutSubset(nodes, edges, direction, nodesep, ranksep) {
+    const g = new dagre.graphlib.Graph();
+    g.setDefaultEdgeLabel(() => ({}));
+    g.setGraph({ rankdir: direction, nodesep, ranksep });
+
+    const nodeWidth = 320;
+    nodes.forEach((node) => {
+        const label = node.data?.Name || '';
+        const height = estimateNodeHeight(label, nodeWidth);
+        g.setNode(node.id, { width: nodeWidth, height });
+    });
+    edges.forEach((edge) => g.setEdge(edge.source, edge.target));
+    dagre.layout(g);
+
+    return nodes.map((node) => {
+        const n = g.node(node.id);
+        if (n) {
+            return {
+                ...node,
+                position: { x: n.x - n.width / 2, y: n.y - n.height / 2 },
+            };
+        }
+        return node;
+    });
+}
+
 export const getLayoutedElements = (
     nodes,
     edges,
@@ -14,77 +41,61 @@ export const getLayoutedElements = (
     nodesep = 35,
     ranksep = 100
 ) => {
-    const dagreGraph = new dagre.graphlib.Graph();
-    dagreGraph.setDefaultEdgeLabel(() => ({}));
-    dagreGraph.setGraph({ rankdir: direction, nodesep, ranksep });
-
     const nodeWidth = 320;
 
-    // Track connected nodes
-    const connectedNodeIds = new Set();
-    edges.forEach((edge) => {
-        connectedNodeIds.add(edge.source);
-        connectedNodeIds.add(edge.target);
-    });
+    // --- Layout top-level nodes (no parentId) ---
+    const topNodes = nodes.filter(n => !n.parentId);
+    const topNodeIds = new Set(topNodes.map(n => n.id));
+    const topEdges = edges.filter(e =>
+        topNodeIds.has(e.source) && topNodeIds.has(e.target)
+    );
+    let layoutedNodes = layoutSubset(topNodes, topEdges, direction, nodesep, ranksep);
 
-    // Add connected nodes to Dagre
-    nodes.forEach((node) => {
-        if (connectedNodeIds.has(node.id)) {
-            const label = node.data?.Name || '';
-            const height = estimateNodeHeight(label, nodeWidth);
-            dagreGraph.setNode(node.id, { width: nodeWidth, height });
-        }
-    });
+    // --- Layout each group (subflow) individually ---
+    const allNodesById = Object.fromEntries(nodes.map(n => [n.id, n]));
+    const childEdges = edges.slice(); // will be reused
 
-    edges.forEach((edge) => {
-        dagreGraph.setEdge(edge.source, edge.target);
-    });
+    layoutedNodes
+        .filter(n => n.type === 'group')
+        .forEach(group => {
+            const children = nodes.filter(n => n.parentId === group.id);
+            if (children.length === 0) return;
 
-    dagre.layout(dagreGraph);
+            const childEdgesForGroup = childEdges.filter(e => {
+                const sParent = allNodesById[e.source]?.parentId;
+                const tParent = allNodesById[e.target]?.parentId;
+                return sParent === group.id && tParent === group.id;
+            });
 
-    // Determine bottom of Dagre layout
-    let maxY = 0;
-    connectedNodeIds.forEach((id) => {
-        const n = dagreGraph.node(id);
-        if (n && n.y != null) {
-            maxY = Math.max(maxY, n.y + n.height / 2);
-        }
-    });
+            const laidOutChildren = layoutSubset(children, childEdgesForGroup, direction, nodesep, ranksep);
 
-    const gridSpacingX = 360;
-    const gridSpacingY = 140;
-    const columns = 8;
-    const gridYOffset = maxY + 200; // Push grid below Dagre layout
-    let gridIndex = 0;
+            // Determine bounding box of children
+            let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+            laidOutChildren.forEach(n => {
+                minX = Math.min(minX, n.position.x);
+                minY = Math.min(minY, n.position.y);
+                maxX = Math.max(maxX, n.position.x + nodeWidth);
+                const h = estimateNodeHeight(n.data?.Name || '', nodeWidth);
+                maxY = Math.max(maxY, n.position.y + h);
+            });
 
-    const layoutedNodes = nodes.map((node) => {
-        const isConnected = connectedNodeIds.has(node.id);
-        const dagreNode = dagreGraph.node(node.id);
+            const padding = 40;
+            const width = maxX - minX + padding * 2;
+            const height = maxY - minY + padding * 2;
 
-        if (isConnected && dagreNode?.x != null && dagreNode?.y != null) {
-            return {
-                ...node,
-                position: {
-                    x: dagreNode.x - dagreNode.width / 2,
-                    y: dagreNode.y - dagreNode.height / 2,
-                },
-            };
-        } else {
-            // Grid fallback layout
-            const col = gridIndex % columns;
-            const row = Math.floor(gridIndex / columns);
-            gridIndex++;
+            // Update group size
+            layoutedNodes = layoutedNodes.map(n =>
+                n.id === group.id ? { ...n, style: { ...n.style, width, height } } : n
+            );
 
-            return {
-                ...node,
-                position: {
-                    x: col * gridSpacingX,
-                    y: gridYOffset + row * gridSpacingY,
-                },
-                positionAbsolute: node.type !== 'group',
-            };
-        }
-    });
+            // Shift children into group coordinate system
+            const offsetX = padding - minX;
+            const offsetY = padding - minY;
+            laidOutChildren.forEach(n => {
+                n.position = { x: n.position.x + offsetX, y: n.position.y + offsetY };
+                layoutedNodes.push(n);
+            });
+        });
 
     return { nodes: layoutedNodes, edges };
 };


### PR DESCRIPTION
## Summary
- simplify and document group node component and enable resizing
- skip successor relations and group nodes when building subflows
- run layout algorithm separately inside each subflow and resize groups to fit

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb772e53083259f1ab4354419e081