### PR TITLE
feat: add Pixi.js AppMap visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.27.13",
         "@lightenna/react-mermaid-diagram": "^1.0.17",
+        "@pixi/react": "^8.0.3",
         "@radix-ui/react-icons": "^1.3.2",
         "@tiptap/extension-highlight": "^2.24.2",
         "@tiptap/extension-image": "^2.24.2",
@@ -38,6 +39,8 @@
         "jquery": "^3.7.1",
         "mermaid": "^11.6.0",
         "openai": "^5.8.2",
+        "pixi-viewport": "^6.0.3",
+        "pixi.js": "^8.13.1",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -5170,6 +5173,29 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/react": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@pixi/react/-/react-8.0.3.tgz",
+      "integrity": "sha512-k0feY0Vj4WIWpaLaRQY8NBKlDqVCPPyEUu5EibQVqdtgdMx1brRWeJC+ruq7Im08vtZWx7iZwNGhgHNubO/OMQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs"
+      ],
+      "dependencies": {
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.31.0"
+      },
+      "peerDependencies": {
+        "pixi.js": "^8.2.6",
+        "react": ">=19.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6261,6 +6287,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -6514,6 +6546,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -6723,6 +6761,25 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
+      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -7205,6 +7262,21 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -11245,6 +11317,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -13053,6 +13131,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -14534,6 +14621,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -14649,6 +14742,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jackspeak": {
@@ -16825,6 +16930,12 @@
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
     },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18410,6 +18521,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -18546,6 +18663,44 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/pixi-viewport": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-6.0.3.tgz",
+      "integrity": "sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pixi.js": ">=8"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.13.1.tgz",
+      "integrity": "sha512-n7lP3FG8noZV00O6ZTUNWQGg2j6xNjK/8TiGviptb4kfyGJvP4zMvF8s6DR0BymZ8P/lix/3Ye5rqilynpl/+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/css-font-loading-module": "^0.0.12",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.40",
+        "@xmldom/xmldom": "^0.8.10",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/pixi.js/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -20597,6 +20752,27 @@
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -24012,6 +24188,15 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.5.tgz",
+      "integrity": "sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.13",
     "@lightenna/react-mermaid-diagram": "^1.0.17",
+    "@pixi/react": "^8.0.3",
     "@radix-ui/react-icons": "^1.3.2",
     "@tiptap/extension-highlight": "^2.24.2",
     "@tiptap/extension-image": "^2.24.2",
@@ -33,6 +34,8 @@
     "jquery": "^3.7.1",
     "mermaid": "^11.6.0",
     "openai": "^5.8.2",
+    "pixi-viewport": "^6.0.3",
+    "pixi.js": "^8.13.1",
     "postcss": "^8.5.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import AppMap from './AppMap/AppMap';
+
+// Simple demo rendering AppMap full screen
+const App = () => (
+  <div style={{ width: '100vw', height: '100vh' }}>
+    <AppMap />
+  </div>
+);
+
+export default App;

--- a/src/AppMap/AppMap.jsx
+++ b/src/AppMap/AppMap.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef } from 'react';
+import { Stage, Container, Graphics, Text, PixiComponent, useApp } from '@pixi/react';
+import { Viewport as PixiViewport } from 'pixi-viewport';
+import useZoomLevel from './useZoomLevel';
+import useAppMapData from './useAppMapData';
+
+// PixiComponent wrapper for pixi-viewport
+const Viewport = PixiComponent('Viewport', {
+  create: ({ app }) => {
+    const viewport = new PixiViewport({
+      screenWidth: app.renderer.width,
+      screenHeight: app.renderer.height,
+      worldWidth: 100000,
+      worldHeight: 100000,
+      interaction: app.renderer.plugins.interaction,
+    });
+
+    // Enable common interactions
+    viewport.drag().pinch().wheel().decelerate();
+    return viewport;
+  },
+});
+
+const AppMapInner = () => {
+  const app = useApp();
+  const viewportRef = useRef(null);
+  const { nodes, loadContainers, loadChildren, updateNodePosition } = useAppMapData();
+  const zoom = useZoomLevel(viewportRef);
+  const dragData = useRef(null);
+
+  useEffect(() => {
+    loadContainers();
+  }, [loadContainers]);
+
+  const onNodeClick = async (node) => {
+    const viewport = viewportRef.current;
+    if (viewport) {
+      viewport.animate({ position: { x: node.x, y: node.y }, scale: Math.max(1, viewport.scale.x) });
+    }
+    await loadChildren(node.id, { x: node.x, y: node.y });
+  };
+
+  const onDragStart = (event, node) => {
+    event.stopPropagation();
+    dragData.current = { id: node.id, data: event.data };
+  };
+
+  const onDragEnd = (event, node) => {
+    if (dragData.current?.id === node.id) {
+      updateNodePosition(node.id, node.x, node.y, true);
+      dragData.current = null;
+    }
+  };
+
+  const onDragMove = (event, node) => {
+    if (!dragData.current || dragData.current.id !== node.id) return;
+    const newPosition = dragData.current.data.getLocalPosition(viewportRef.current);
+    updateNodePosition(node.id, newPosition.x, newPosition.y, false);
+  };
+
+  return (
+    <Viewport ref={viewportRef} app={app} worldWidth={100000} worldHeight={100000}>
+      {nodes.map((node) => {
+        const label =
+          zoom < 0.2
+            ? ''
+            : zoom < 1
+            ? node.name
+            : `${node.name}${node.description ? ' - ' + node.description : ''}`;
+        return (
+          <Container
+            key={node.id}
+            x={node.x}
+            y={node.y}
+            eventMode="dynamic"
+            cursor="pointer"
+            pointerdown={(e) => onDragStart(e, node)}
+            pointerup={(e) => onDragEnd(e, node)}
+            pointerupoutside={(e) => onDragEnd(e, node)}
+            pointermove={(e) => onDragMove(e, node)}
+            onclick={() => onNodeClick(node)}
+          >
+            <Graphics
+              draw={(g) => {
+                g.clear();
+                g.beginFill(0x3498db);
+                g.drawCircle(0, 0, 10);
+                g.endFill();
+              }}
+            />
+            {label && (
+              <Text text={label} anchor={0.5} y={-20} style={{ fill: '#000', fontSize: 14 / zoom }} />
+            )}
+          </Container>
+        );
+      })}
+    </Viewport>
+  );
+};
+
+const AppMap = () => (
+  <Stage
+    width={window.innerWidth}
+    height={window.innerHeight}
+    options={{ backgroundColor: 0xffffff }}
+    style={{ width: '100vw', height: '100vh' }}
+  >
+    <AppMapInner />
+  </Stage>
+);
+
+export default AppMap;

--- a/src/AppMap/useAppMapData.js
+++ b/src/AppMap/useAppMapData.js
@@ -1,0 +1,55 @@
+import { useState, useCallback } from 'react';
+import { fetchContainers as getContainers, fetchChildren as getChildren, setPosition } from '../api';
+
+// Hook to manage loading and storing container nodes
+export default function useAppMapData() {
+  const [nodes, setNodes] = useState([]);
+
+  // Load top-level containers
+  const loadContainers = useCallback(async () => {
+    const data = await getContainers();
+    if (!data) return;
+    setNodes(
+      data.map((c) => ({
+        id: c.id,
+        name: c.name || '',
+        description: c.description || '',
+        x: c.position?.x ?? Math.random() * 1000,
+        y: c.position?.y ?? Math.random() * 1000,
+      }))
+    );
+  }, []);
+
+  // Load child containers around a parent
+  const loadChildren = useCallback(async (id, parentPos) => {
+    const children = await getChildren(id);
+    if (!children) return;
+    const angleStep = (2 * Math.PI) / Math.max(children.length, 1);
+    const processed = children.map((c, i) => ({
+      id: c.id,
+      name: c.name || '',
+      description: c.description || '',
+      x: c.position?.x ?? parentPos.x + Math.cos(i * angleStep) * 150,
+      y: c.position?.y ?? parentPos.y + Math.sin(i * angleStep) * 150,
+    }));
+    setNodes((prev) => {
+      const existing = new Set(prev.map((n) => n.id));
+      const newNodes = processed.filter((n) => !existing.has(n.id));
+      return [...prev, ...newNodes];
+    });
+  }, []);
+
+  // Update a node's position, optionally persisting to backend
+  const updateNodePosition = useCallback((id, x, y, persist = false) => {
+    setNodes((prev) => prev.map((n) => (n.id === id ? { ...n, x, y } : n)));
+    if (persist) {
+      try {
+        setPosition(id, id, { x, y });
+      } catch (err) {
+        console.error('Failed to save position', err);
+      }
+    }
+  }, []);
+
+  return { nodes, loadContainers, loadChildren, updateNodePosition };
+}

--- a/src/AppMap/useZoomLevel.js
+++ b/src/AppMap/useZoomLevel.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+// Hook to track the current zoom level of the viewport
+export default function useZoomLevel(viewportRef) {
+  const [zoom, setZoom] = useState(1);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const updateZoom = () => setZoom(viewport.scale.x);
+
+    // Listen to pixi-viewport's zoomed event
+    viewport.on('zoomed', updateZoom);
+    updateZoom();
+
+    return () => {
+      viewport.off('zoomed', updateZoom);
+    };
+  }, [viewportRef]);
+
+  return zoom;
+}


### PR DESCRIPTION
## Summary
- add AppMap React sub-app using Pixi.js and pixi-viewport
- load containers and children via existing api.js helpers
- show labels based on zoom level and persist node positions on drag

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bf36b6ebec8325bd675c698bf42514