### PR TITLE
fix: ensure AppMap builds with pixi-viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "mermaid": "^11.6.0",
         "openai": "^5.8.2",
         "pixi-viewport": "^5.0.2",
-        "pixi.js": "^8.4.1",
+        "pixi.js": "^7.4.3",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -5172,11 +5172,386 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pixi/accessibility": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
+      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
+      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
+      "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-font-loading-module": "^0.0.12"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/color": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
+      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
       "license": "MIT"
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
+      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/constants": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
+      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/math": "7.4.3",
+        "@pixi/runner": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/ticker": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
+      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
+      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/extensions": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
+      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/extract": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
+      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
+      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
+      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
+      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
+      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
+      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
+      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
+      "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/math": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
+      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
+      "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
+      "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/mesh": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
+      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
+      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
+      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
+      "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
+      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/runner": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
+      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/settings": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
+      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/constants": "7.4.3",
+        "@types/css-font-loading-module": "^0.0.12",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
+      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
+      "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
+      "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
+      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
+      "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
+      "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
+      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
+      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/extensions": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
+      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -7236,21 +7611,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.64",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
-      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -18468,12 +18828,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "license": "MIT"
-    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -18618,27 +18972,46 @@
       "license": "MIT"
     },
     "node_modules/pixi.js": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.4.1.tgz",
-      "integrity": "sha512-3ZbEIkLYYi602UB5wuN7kPz3VsGHoJa6nxD8ustvMLRySxHAR9Z8tCAYY8ISgNplpPbaDw03B0yTD4/k9f6cAQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
+      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
       "license": "MIT",
       "dependencies": {
-        "@pixi/colord": "^2.9.6",
-        "@types/css-font-loading-module": "^0.0.12",
-        "@types/earcut": "^2.1.4",
-        "@webgpu/types": "^0.1.40",
-        "@xmldom/xmldom": "^0.8.10",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^5.0.1",
-        "ismobilejs": "^1.1.1",
-        "parse-svg-path": "^0.1.2"
+        "@pixi/accessibility": "7.4.3",
+        "@pixi/app": "7.4.3",
+        "@pixi/assets": "7.4.3",
+        "@pixi/compressed-textures": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/extract": "7.4.3",
+        "@pixi/filter-alpha": "7.4.3",
+        "@pixi/filter-blur": "7.4.3",
+        "@pixi/filter-color-matrix": "7.4.3",
+        "@pixi/filter-displacement": "7.4.3",
+        "@pixi/filter-fxaa": "7.4.3",
+        "@pixi/filter-noise": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/mesh-extras": "7.4.3",
+        "@pixi/mixin-cache-as-bitmap": "7.4.3",
+        "@pixi/mixin-get-child-by-name": "7.4.3",
+        "@pixi/mixin-get-global-position": "7.4.3",
+        "@pixi/particle-container": "7.4.3",
+        "@pixi/prepare": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/sprite-animated": "7.4.3",
+        "@pixi/sprite-tiling": "7.4.3",
+        "@pixi/spritesheet": "7.4.3",
+        "@pixi/text": "7.4.3",
+        "@pixi/text-bitmap": "7.4.3",
+        "@pixi/text-html": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
-    },
-    "node_modules/pixi.js/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -24648,6 +25021,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -24657,6 +25043,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mermaid": "^11.6.0",
     "openai": "^5.8.2",
     "pixi-viewport": "^5.0.2",
-    "pixi.js": "^8.4.1",
+    "pixi.js": "^7.4.3",
     "postcss": "^8.5.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/AppMap.jsx
+++ b/src/AppMap.jsx
@@ -28,6 +28,9 @@ export default function AppMap() {
     console.log("Initializing PIXI Application");
     console.log("Row data count:", rowData.length);
 
+    // Capture refs for cleanup
+    const nodes = nodesRef.current;
+
     const app = new PIXI.Application();
 
     // Initialize the app (PIXI v8 async initialization)
@@ -166,8 +169,8 @@ export default function AppMap() {
 
     return () => {
       // Cleanup
-      if (nodesRef.current) {
-        nodesRef.current.clear();
+      if (nodes) {
+        nodes.clear();
       }
 
       if (appRef.current && !appRef.current.destroyed) {


### PR DESCRIPTION
## Summary
- downgrade pixi.js to v7 so pixi-viewport can resolve @pixi modules
- clean up AppMap node references to satisfy React hook rules

## Testing
- `npm run build`
- `npx eslint src/AppMap.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68bf46670a0883258327499c1bb8be8d