### PR TITLE
refactor: use infinite canvas for AppMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "bootstrap": "^5.3.3",
         "dagre": "^0.8.5",
         "docx": "^9.5.1",
+        "ef-infinite-canvas": "^0.6.9",
         "html-to-docx": "^1.8.0",
         "jquery": "^3.7.1",
         "mermaid": "^11.6.0",
@@ -10680,6 +10681,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/ef-infinite-canvas": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ef-infinite-canvas/-/ef-infinite-canvas-0.6.9.tgz",
+      "integrity": "sha512-U5js7uqNOT8/5YXwcdw2GZfOWO3wLuY7rmisrST4epNOLdLZ8s+ma5V0rniE5c5RHno92+y5czkoZVY6aODE7A==",
       "license": "MIT"
     },
     "node_modules/ejs": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bootstrap": "^5.3.3",
     "dagre": "^0.8.5",
     "docx": "^9.5.1",
+    "ef-infinite-canvas": "^0.6.9",
     "html-to-docx": "^1.8.0",
     "jquery": "^3.7.1",
     "mermaid": "^11.6.0",

--- a/src/AppMap.jsx
+++ b/src/AppMap.jsx
@@ -37,11 +37,38 @@ export default function AppMap() {
     ctx.fill();
 
     const handleResize = () => {
-      infiniteCanvas.resize();
+      if (!canvasRef.current) return;
+      // Set canvas width/height to match container
+      const parent = canvasRef.current.parentElement;
+      if (parent) {
+        canvasRef.current.width = parent.offsetWidth;
+        canvasRef.current.height = parent.offsetHeight;
+      }
+      // Optionally, you may want to re-initialize InfiniteCanvas or redraw here
+      // For now, just clear and redraw grid
+      const ctx = infiniteCanvas.getContext("2d");
+      ctx.clearRect(-1000, -1000, 2000, 2000);
+      ctx.strokeStyle = "#ccc";
+      for (let x = -1000; x <= 1000; x += 50) {
+        ctx.beginPath();
+        ctx.moveTo(x, -1000);
+        ctx.lineTo(x, 1000);
+        ctx.stroke();
+      }
+      for (let y = -1000; y <= 1000; y += 50) {
+        ctx.beginPath();
+        ctx.moveTo(-1000, y);
+        ctx.lineTo(1000, y);
+        ctx.stroke();
+      }
+      ctx.beginPath();
+      ctx.fillStyle = "red";
+      ctx.arc(0, 0, 40, 0, Math.PI * 2);
+      ctx.fill();
     };
 
     window.addEventListener("resize", handleResize);
-    infiniteCanvas.resize();
+    handleResize();
 
     return () => {
       window.removeEventListener("resize", handleResize);

--- a/src/AppMap.jsx
+++ b/src/AppMap.jsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useRef } from "react";
 import { useAppContext } from "./AppContext";
 import InfiniteCanvas from "ef-infinite-canvas";
+import { useNodes } from "./hooks/useNodes";
 
 export default function AppMap() {
   const canvasRef = useRef(null);
   const infiniteCanvasRef = useRef(null);
+  const redrawRef = useRef(() => {});
   const { rowData } = useAppContext();
+
+  const { redraw } = useNodes(infiniteCanvasRef.current, rowData);
+  redrawRef.current = redraw;
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -13,58 +18,16 @@ export default function AppMap() {
 
     const infiniteCanvas = new InfiniteCanvas(canvas);
     infiniteCanvasRef.current = infiniteCanvas;
-    const ctx = infiniteCanvas.getContext("2d");
-
-    ctx.strokeStyle = "#ccc";
-
-    for (let x = -1000; x <= 1000; x += 50) {
-      ctx.beginPath();
-      ctx.moveTo(x, -1000);
-      ctx.lineTo(x, 1000);
-      ctx.stroke();
-    }
-
-    for (let y = -1000; y <= 1000; y += 50) {
-      ctx.beginPath();
-      ctx.moveTo(-1000, y);
-      ctx.lineTo(1000, y);
-      ctx.stroke();
-    }
-
-    ctx.beginPath();
-    ctx.fillStyle = "red";
-    ctx.arc(0, 0, 40, 0, Math.PI * 2);
-    ctx.fill();
 
     const handleResize = () => {
       if (!canvasRef.current) return;
-      // Set canvas width/height to match container
       const parent = canvasRef.current.parentElement;
       if (parent) {
         canvasRef.current.width = parent.offsetWidth;
         canvasRef.current.height = parent.offsetHeight;
       }
-      // Optionally, you may want to re-initialize InfiniteCanvas or redraw here
-      // For now, just clear and redraw grid
-      const ctx = infiniteCanvas.getContext("2d");
-      ctx.clearRect(-1000, -1000, 2000, 2000);
-      ctx.strokeStyle = "#ccc";
-      for (let x = -1000; x <= 1000; x += 50) {
-        ctx.beginPath();
-        ctx.moveTo(x, -1000);
-        ctx.lineTo(x, 1000);
-        ctx.stroke();
-      }
-      for (let y = -1000; y <= 1000; y += 50) {
-        ctx.beginPath();
-        ctx.moveTo(-1000, y);
-        ctx.lineTo(1000, y);
-        ctx.stroke();
-      }
-      ctx.beginPath();
-      ctx.fillStyle = "red";
-      ctx.arc(0, 0, 40, 0, Math.PI * 2);
-      ctx.fill();
+      // redraw grid and nodes after resize
+      if (redrawRef.current) redrawRef.current();
     };
 
     window.addEventListener("resize", handleResize);

--- a/src/hooks/useNodes.js
+++ b/src/hooks/useNodes.js
@@ -18,6 +18,11 @@ export const useNodes = (infiniteCanvas, incomingNodes = []) => {
     }, [nodes]);
 
     // Initialize node positions whenever incoming list changes
+    const BASE_RADIUS = 40;
+    const RADIUS_SCALE = 0.5;
+    const BASE_FONT_SIZE = 16;
+    const FONT_SCALE = 0.7;
+    const LEVELS = 4; // Parent, Child, Grandchild, Great-Grandchild
     useEffect(() => {
         if (!incomingNodes) return;
 
@@ -33,7 +38,7 @@ export const useNodes = (infiniteCanvas, incomingNodes = []) => {
         // Recursive node adder for levels
         const positioned = [];
         const addNode = (row, index, parentPos = null, level = 0) => {
-            if (level > 2) return; // Only render up to grandchildren
+            if (level > LEVELS) return; // Only render up to grandchildren
 
             // Color and size by level
             const getNodeColor = (level) => {
@@ -42,10 +47,6 @@ export const useNodes = (infiniteCanvas, incomingNodes = []) => {
                 if (level === 2) return "#27ae60";      // Grandchild: green
                 return "#95a5a6";                       // Others: gray
             };
-            const BASE_RADIUS = 40;
-            const RADIUS_SCALE = 0.5;
-            const BASE_FONT_SIZE = 16;
-            const FONT_SCALE = 0.7;
 
             const radius = Math.max(8, BASE_RADIUS * Math.pow(RADIUS_SCALE, level));
             const fontSize = Math.max(8, BASE_FONT_SIZE * Math.pow(FONT_SCALE, level));
@@ -81,7 +82,7 @@ export const useNodes = (infiniteCanvas, incomingNodes = []) => {
             });
 
             // Render children (only if within level limit)
-            if (level < 2) {
+            if (level < LEVELS) {
                 const children = getChildren(row.id);
                 children.forEach((child, childIdx) => {
                     let childRow;
@@ -137,7 +138,7 @@ export const useNodes = (infiniteCanvas, incomingNodes = []) => {
 
     const drawNodes = (ctx) => {
         ctx.textAlign = "center";
-        ctx.textBaseline = "bottom";
+        ctx.textBaseline = "middle";
         nodesRef.current.forEach((n) => {
             // Draw node circle
             ctx.beginPath();

--- a/src/hooks/useNodes.js
+++ b/src/hooks/useNodes.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Hook integrating nodes rendering and dragging with an InfiniteCanvas instance.
@@ -6,126 +6,129 @@ import { useEffect, useRef, useState } from "react";
  * @param {Array} incomingNodes - array of node objects with optional { id, label, x, y }
  */
 export const useNodes = (infiniteCanvas, incomingNodes = []) => {
-  const [nodes, setNodes] = useState([]);
-  const selectedRef = useRef(null);
-  const nodesRef = useRef(nodes);
+    const [nodes, setNodes] = useState([]);
+    const selectedRef = useRef(null);
+    const nodesRef = useRef(nodes);
 
-  // Keep refs in sync
-  useEffect(() => {
-    nodesRef.current = nodes;
-  }, [nodes]);
+    // Keep refs in sync
+    useEffect(() => {
+        nodesRef.current = nodes;
+    }, [nodes]);
 
-  // Initialize node positions whenever incoming list changes
-  useEffect(() => {
-    if (!incomingNodes) return;
-    const positioned = incomingNodes.map((n, idx) => ({
-      id: n.id ?? idx,
-      label: n.label || n.name || `Node ${idx}`,
-      x: n.x ?? n.position?.x ?? 100 + idx * 80,
-      y: n.y ?? n.position?.y ?? 100 + idx * 80,
-    }));
-    setNodes(positioned);
-  }, [incomingNodes]);
+    // Initialize node positions whenever incoming list changes
+    useEffect(() => {
+        if (!incomingNodes) return;
+        const positioned = incomingNodes.map((n, idx) => {
+            console.log('useNodes: node object', n);
+            return {
+                id: n.id ?? idx,
+                label: n.label || n.Name || `Node ${idx}`,
+                x: n.x ?? n.position?.x ?? 100 + idx * 80,
+                y: n.y ?? n.position?.y ?? 100 + idx * 80,
+            };
+        });
+        setNodes(positioned);
+    }, [incomingNodes]);
 
-  // Drawing helpers
-  const drawGrid = (ctx) => {
-    ctx.strokeStyle = "#ccc";
-    for (let x = -1000; x <= 1000; x += 50) {
-      ctx.beginPath();
-      ctx.moveTo(x, -1000);
-      ctx.lineTo(x, 1000);
-      ctx.stroke();
-    }
-    for (let y = -1000; y <= 1000; y += 50) {
-      ctx.beginPath();
-      ctx.moveTo(-1000, y);
-      ctx.lineTo(1000, y);
-      ctx.stroke();
-    }
-  };
-
-  const drawNodes = (ctx) => {
-    ctx.fillStyle = "blue";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "top";
-    ctx.font = "16px sans-serif";
-    nodesRef.current.forEach((n) => {
-      ctx.beginPath();
-      ctx.arc(n.x, n.y, 30, 0, 2 * Math.PI);
-      ctx.fill();
-      ctx.fillStyle = "white";
-      ctx.fillText(n.label, n.x, n.y + 35);
-      ctx.fillStyle = "blue"; // reset for next node
-    });
-  };
-
-  const redraw = () => {
-    if (!infiniteCanvas) return;
-    const ctx = infiniteCanvas.getContext("2d");
-    ctx.save();
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    ctx.restore();
-    drawGrid(ctx);
-    drawNodes(ctx);
-  };
-
-  // Redraw whenever nodes or canvas change
-  useEffect(() => {
-    redraw();
-  }, [infiniteCanvas, nodes]);
-
-  // Event handling for dragging
-  useEffect(() => {
-    if (!infiniteCanvas) return;
-    const canvas = infiniteCanvas.canvas;
-    const ctx = infiniteCanvas.getContext("2d");
-
-    const getPos = (e) => {
-      const rect = canvas.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const inv = ctx.getTransform().invertSelf();
-      const pt = new DOMPoint(x, y).matrixTransform(inv);
-      return { x: pt.x, y: pt.y };
+    // Drawing helpers
+    const drawGrid = (ctx) => {
+        ctx.strokeStyle = "#ccc";
+        for (let x = -1000; x <= 1000; x += 50) {
+            ctx.beginPath();
+            ctx.moveTo(x, -1000);
+            ctx.lineTo(x, 1000);
+            ctx.stroke();
+        }
+        for (let y = -1000; y <= 1000; y += 50) {
+            ctx.beginPath();
+            ctx.moveTo(-1000, y);
+            ctx.lineTo(1000, y);
+            ctx.stroke();
+        }
     };
 
-    const onDown = (e) => {
-      const pos = getPos(e);
-      const hit = nodesRef.current.find(
-        (n) => Math.hypot(n.x - pos.x, n.y - pos.y) <= 30
-      );
-      if (hit) {
-        selectedRef.current = hit.id;
-      }
+    const drawNodes = (ctx) => {
+        ctx.fillStyle = "blue";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "top";
+        ctx.font = "16px sans-serif";
+        nodesRef.current.forEach((n) => {
+            ctx.beginPath();
+            ctx.arc(n.x, n.y, 30, 0, 2 * Math.PI);
+            ctx.fill();
+            ctx.fillStyle = "white";
+            ctx.fillText(n.label, n.x, n.y + 35);
+            ctx.fillStyle = "blue"; // reset for next node
+        });
     };
 
-    const onMove = (e) => {
-      if (selectedRef.current == null) return;
-      const pos = getPos(e);
-      setNodes((ns) =>
-        ns.map((n) =>
-          n.id === selectedRef.current ? { ...n, x: pos.x, y: pos.y } : n
-        )
-      );
-    };
+    const redraw = useCallback(() => {
+        if (!infiniteCanvas) return;
+        const ctx = infiniteCanvas.getContext("2d");
+        ctx.save();
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        ctx.restore();
+        drawGrid(ctx);
+        drawNodes(ctx);
+    }, [infiniteCanvas]);
 
-    const onUp = () => {
-      selectedRef.current = null;
-    };
+    // Redraw whenever nodes or canvas change
+    useEffect(() => {
+        redraw();
+    }, [infiniteCanvas, nodes, redraw]);
 
-    canvas.addEventListener("mousedown", onDown);
-    canvas.addEventListener("mousemove", onMove);
-    canvas.addEventListener("mouseup", onUp);
+    // Event handling for dragging
+    useEffect(() => {
+        if (!infiniteCanvas) return;
+        const canvas = infiniteCanvas.canvas;
+        const ctx = infiniteCanvas.getContext("2d");
 
-    return () => {
-      canvas.removeEventListener("mousedown", onDown);
-      canvas.removeEventListener("mousemove", onMove);
-      canvas.removeEventListener("mouseup", onUp);
-    };
-  }, [infiniteCanvas]);
+        const getPos = (e) => {
+            const rect = canvas.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            const inv = ctx.getTransform().invertSelf();
+            const pt = new DOMPoint(x, y).matrixTransform(inv);
+            return { x: pt.x, y: pt.y };
+        };
 
-  return { nodes, setNodes, redraw };
+        const onDown = (e) => {
+            const pos = getPos(e);
+            const hit = nodesRef.current.find(
+                (n) => Math.hypot(n.x - pos.x, n.y - pos.y) <= 30
+            );
+            if (hit) {
+                selectedRef.current = hit.id;
+            }
+        };
+
+        const onMove = (e) => {
+            if (selectedRef.current == null) return;
+            const pos = getPos(e);
+            setNodes((ns) =>
+                ns.map((n) =>
+                    n.id === selectedRef.current ? { ...n, x: pos.x, y: pos.y } : n
+                )
+            );
+        };
+
+        const onUp = () => {
+            selectedRef.current = null;
+        };
+
+        canvas.addEventListener("mousedown", onDown);
+        canvas.addEventListener("mousemove", onMove);
+        canvas.addEventListener("mouseup", onUp);
+
+        return () => {
+            canvas.removeEventListener("mousedown", onDown);
+            canvas.removeEventListener("mousemove", onMove);
+            canvas.removeEventListener("mouseup", onUp);
+        };
+    }, [infiniteCanvas]);
+
+    return { nodes, setNodes, redraw };
 };
 
 export default useNodes;

--- a/src/hooks/useNodes.js
+++ b/src/hooks/useNodes.js
@@ -1,257 +1,131 @@
-import { useEffect, useRef } from 'react';
-import * as PIXI from 'pixi.js';
-import { useAppContext } from '../AppContext';
+import { useEffect, useRef, useState } from "react";
 
-export const useNodes = (viewport, rowData, updateNodePosition, dragStateRef, zoom = 1) => {
-    const nodesRef = useRef(new Map());
-    const { parentChildMap } = useAppContext();
+/**
+ * Hook integrating nodes rendering and dragging with an InfiniteCanvas instance.
+ * @param {InfiniteCanvas} infiniteCanvas - instance returned from `new InfiniteCanvas(canvas)`
+ * @param {Array} incomingNodes - array of node objects with optional { id, label, x, y }
+ */
+export const useNodes = (infiniteCanvas, incomingNodes = []) => {
+  const [nodes, setNodes] = useState([]);
+  const selectedRef = useRef(null);
+  const nodesRef = useRef(nodes);
 
-    const createNodeGraphics = (radius = 20, color = 0x3498db) => {
-        const graphics = new PIXI.Graphics();
-        graphics.beginFill(color);
-        graphics.drawCircle(0, 0, radius);
-        graphics.endFill();
-        return graphics;
+  // Keep refs in sync
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
+
+  // Initialize node positions whenever incoming list changes
+  useEffect(() => {
+    if (!incomingNodes) return;
+    const positioned = incomingNodes.map((n, idx) => ({
+      id: n.id ?? idx,
+      label: n.label || n.name || `Node ${idx}`,
+      x: n.x ?? n.position?.x ?? 100 + idx * 80,
+      y: n.y ?? n.position?.y ?? 100 + idx * 80,
+    }));
+    setNodes(positioned);
+  }, [incomingNodes]);
+
+  // Drawing helpers
+  const drawGrid = (ctx) => {
+    ctx.strokeStyle = "#ccc";
+    for (let x = -1000; x <= 1000; x += 50) {
+      ctx.beginPath();
+      ctx.moveTo(x, -1000);
+      ctx.lineTo(x, 1000);
+      ctx.stroke();
+    }
+    for (let y = -1000; y <= 1000; y += 50) {
+      ctx.beginPath();
+      ctx.moveTo(-1000, y);
+      ctx.lineTo(1000, y);
+      ctx.stroke();
+    }
+  };
+
+  const drawNodes = (ctx) => {
+    ctx.fillStyle = "blue";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.font = "16px sans-serif";
+    nodesRef.current.forEach((n) => {
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, 30, 0, 2 * Math.PI);
+      ctx.fill();
+      ctx.fillStyle = "white";
+      ctx.fillText(n.label, n.x, n.y + 35);
+      ctx.fillStyle = "blue"; // reset for next node
+    });
+  };
+
+  const redraw = () => {
+    if (!infiniteCanvas) return;
+    const ctx = infiniteCanvas.getContext("2d");
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    ctx.restore();
+    drawGrid(ctx);
+    drawNodes(ctx);
+  };
+
+  // Redraw whenever nodes or canvas change
+  useEffect(() => {
+    redraw();
+  }, [infiniteCanvas, nodes]);
+
+  // Event handling for dragging
+  useEffect(() => {
+    if (!infiniteCanvas) return;
+    const canvas = infiniteCanvas.canvas;
+    const ctx = infiniteCanvas.getContext("2d");
+
+    const getPos = (e) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const inv = ctx.getTransform().invertSelf();
+      const pt = new DOMPoint(x, y).matrixTransform(inv);
+      return { x: pt.x, y: pt.y };
     };
 
-    const createNodeText = (label, fontSize = 12, wrapWidth = 60) => {
-        return new PIXI.Text(label, {
-            fontFamily: "Arial",
-            fontSize,
-            fill: 0x000000,
-            align: "center",
-            wordWrap: true,
-            wordWrapWidth: wrapWidth,
-            resolution: 4, // Sharper text at high zoom
-        });
+    const onDown = (e) => {
+      const pos = getPos(e);
+      const hit = nodesRef.current.find(
+        (n) => Math.hypot(n.x - pos.x, n.y - pos.y) <= 30
+      );
+      if (hit) {
+        selectedRef.current = hit.id;
+      }
     };
 
-    // Main effect: create nodes
-    useEffect(() => {
-        if (!viewport || !rowData) return;
-
-        let cancelled = false;
-        const nodesMap = nodesRef.current; // Capture ref value
-
-        const renderNodes = () => {
-            if (cancelled) return;
-
-            // Remove old nodes
-            nodesMap.forEach(nodeContainer => {
-                viewport.removeChild(nodeContainer);
-            });
-            nodesMap.clear();
-
-            // Get visible bounds with margin
-            const visibleBounds = viewport.getVisibleBounds();
-            const margin = 200;
-            const expandedBounds = {
-                x: visibleBounds.x - margin,
-                y: visibleBounds.y - margin,
-                width: visibleBounds.width + margin * 2,
-                height: visibleBounds.height + margin * 2,
-            };
-
-            // console.log("parentChildMap:", parentChildMap);
-            // Helpers
-            const getChildren = (parentId) => {
-                const entry = parentChildMap?.find(e => e.container_id === parentId);
-                return entry?.children || [];
-            };
-            const getNodeById = (id) => rowData.find(r => r.id === id);
-
-            // Recursive node adder, now with level limit
-            const addNode = (row, index, parentPos = null, level = 0) => {
-                if (level > 2) return; // Only render up to grandchildren
-                const isChild = level > 0;
-
-                const getNodeColor = (level) => {
-                    if (level === 0) return 0x3498db;      // Parent: blue
-                    if (level === 1) return 0xe67e22;      // Child: orange
-                    if (level === 2) return 0x27ae60;      // Grandchild: green
-                    return 0x95a5a6;                       // Others: gray
-                };
-
-                // Parameters for scaling
-                const BASE_RADIUS = 100;      // Size for level 0 (root)
-                const RADIUS_SCALE = 0.2;     // Each level is 40% the size of the previous
-                const BASE_FONT_SIZE = 24;    // Font size for level 0
-                const FONT_SCALE = 0.1;       // Each level is 40% the font size of the previous
-                const BASE_WRAP = 200;        // Wrap width for level 0
-                const WRAP_SCALE = 0.5;       // Each level is 50% the wrap width of the previous
-
-                // Calculate mathematically for each level
-                const radius = Math.max(8, BASE_RADIUS * Math.pow(RADIUS_SCALE, level));
-                const fontSize = Math.max(6, BASE_FONT_SIZE * Math.pow(FONT_SCALE, level));
-                const wrapWidth = Math.max(16, BASE_WRAP * Math.pow(WRAP_SCALE, level));
-
-                // For root nodes, use their own position or grid
-                let nodeX = parentPos
-                    ? parentPos.x
-                    : row.position?.x ?? 100 + (index % 5) * 150;
-                let nodeY = parentPos
-                    ? parentPos.y
-                    : row.position?.y ?? 100 + Math.floor(index / 5) * 100;
-
-                // For children/grandchildren, arrange in a circle inside parent
-                if (parentPos && parentPos.childCount > 1) {
-                    // Calculate orbit radius so children fit inside parent
-                    const orbit = Math.max(0, radius * 2, (BASE_RADIUS - radius - 4));
-                    const angle = (2 * Math.PI * index) / parentPos.childCount;
-                    nodeX = parentPos.x + Math.cos(angle) * orbit;
-                    nodeY = parentPos.y + Math.sin(angle) * orbit;
-                }
-
-                // Only render if in expanded bounds
-                if (
-                    nodeX < expandedBounds.x ||
-                    nodeX > expandedBounds.x + expandedBounds.width ||
-                    nodeY < expandedBounds.y ||
-                    nodeY > expandedBounds.y + expandedBounds.height
-                ) {
-                    return;
-                }
-
-                // LOD: Only render grandchildren if zoomed in
-                // if (level === 2 && zoom < 1.2) return;
-
-                const color = getNodeColor(level);
-
-                const nodeContainer = new PIXI.Container();
-                nodeContainer.x = nodeX;
-                nodeContainer.y = nodeY;
-                nodeContainer.interactive = true;
-                nodeContainer.buttonMode = true;
-
-                // Circle with color by level
-                const graphics = createNodeGraphics(radius, color);
-                nodeContainer.addChild(graphics);
-
-                // Label
-                const label = row.name || row.Name || row.id || "Unknown";
-                const text = createNodeText(label, fontSize, wrapWidth);
-                text.anchor.set(0.5);
-                text.y = -radius - (isChild ? 8 : 20) * 2;
-                nodeContainer.addChild(text);
-
-                // Drag logic (only for parent nodes)
-                let isNodeDragging = false;
-                let nodeDragOffset = null;
-
-                const onNodeDragStart = (event) => {
-                    isNodeDragging = true;
-                    dragStateRef.current.isDraggingNode = true;
-                    const globalPos = event.data.global;
-                    const localPos = viewport.toLocal(globalPos);
-                    nodeDragOffset = {
-                        x: localPos.x - nodeContainer.x,
-                        y: localPos.y - nodeContainer.y,
-                    };
-                    nodeContainer.alpha = 0.7;
-                    nodeContainer.cursor = "grabbing";
-                };
-
-                const onNodeDragMove = (event) => {
-                    if (!isNodeDragging || !nodeDragOffset) return;
-                    const globalPos = event.data.global;
-                    const localPos = viewport.toLocal(globalPos);
-                    nodeContainer.x = localPos.x - nodeDragOffset.x;
-                    nodeContainer.y = localPos.y - nodeDragOffset.y;
-                };
-
-                const onNodeDragEnd = () => {
-                    if (isNodeDragging) {
-                        isNodeDragging = false;
-                        dragStateRef.current.isDraggingNode = false;
-                        nodeDragOffset = null;
-                        nodeContainer.alpha = 1;
-                        nodeContainer.cursor = "pointer";
-                        updateNodePosition(row.id, nodeContainer.x, nodeContainer.y);
-                    }
-                };
-
-                nodeContainer.on("mousedown", onNodeDragStart);
-                nodeContainer.on("mousemove", onNodeDragMove);
-                nodeContainer.on("mouseup", onNodeDragEnd);
-                nodeContainer.on("mouseupoutside", onNodeDragEnd);
-                nodeContainer.on("touchstart", onNodeDragStart);
-                nodeContainer.on("touchmove", onNodeDragMove);
-                nodeContainer.on("touchend", onNodeDragEnd);
-                nodeContainer.on("touchendoutside", onNodeDragEnd);
-                nodeContainer.on("click", () => {
-                    console.log(`Clicked node: ${label}`);
-                });
-
-                viewport.addChild(nodeContainer);
-                nodesMap.set(`${row.id}_${isChild ? 'child' : 'parent'}_${Math.random()}`, nodeContainer);
-
-                // Render children (only if zoomed in enough and within level limit)
-                if (level < 2) {
-                    const children = getChildren(row.id);
-                    children.forEach((child, childIdx) => {
-                        let childRow;
-                        if (typeof child === "object") {
-                            childRow = child.id
-                                ? child
-                                : getNodeById(child.container_id); // fallback if no id, but has container_id
-                        } else {
-                            childRow = getNodeById(child);
-                        }
-                        if (childRow) {
-                            addNode(
-                                childRow,
-                                childIdx,
-                                { x: nodeContainer.x, y: nodeContainer.y, childCount: children.length },
-                                level + 1
-                            );
-                        }
-                    });
-                }
-            };
-
-            // Add all top-level nodes (not children in parentChildMap)
-            const childIds = new Set();
-            parentChildMap?.forEach(entry => {
-                (entry.children || []).forEach(child => childIds.add(child.id || child));
-            });
-            rowData.forEach((row, index) => {
-                if (!childIds.has(row.id)) {
-                    addNode(row, index, null, 0); // Start at level 0
-                }
-            });
-        };
-
-        renderNodes();
-
-        // Listen for viewport move/zoom
-        viewport.on("moved", renderNodes);
-        viewport.on("zoomed", renderNodes);
-
-        return () => {
-            cancelled = true;
-            viewport.off("moved", renderNodes);
-            viewport.off("zoomed", renderNodes);
-            // Clean up nodes using captured nodesMap
-            nodesMap.forEach(nodeContainer => {
-                viewport.removeChild(nodeContainer);
-            });
-            nodesMap.clear();
-        };
-    }, [viewport, rowData, updateNodePosition, dragStateRef, parentChildMap, zoom]);
-
-    // Effect: update label visibility on zoom
-    useEffect(() => {
-        nodesRef.current.forEach((nodeContainer) => {
-            const textObj = nodeContainer.children.find(
-                child => child instanceof PIXI.Text
-            );
-            if (textObj) {
-                textObj.visible = zoom >= 1;
-            }
-        });
-    }, [zoom, viewport]);
-
-    return {
-        nodes: nodesRef.current
+    const onMove = (e) => {
+      if (selectedRef.current == null) return;
+      const pos = getPos(e);
+      setNodes((ns) =>
+        ns.map((n) =>
+          n.id === selectedRef.current ? { ...n, x: pos.x, y: pos.y } : n
+        )
+      );
     };
+
+    const onUp = () => {
+      selectedRef.current = null;
+    };
+
+    canvas.addEventListener("mousedown", onDown);
+    canvas.addEventListener("mousemove", onMove);
+    canvas.addEventListener("mouseup", onUp);
+
+    return () => {
+      canvas.removeEventListener("mousedown", onDown);
+      canvas.removeEventListener("mousemove", onMove);
+      canvas.removeEventListener("mouseup", onUp);
+    };
+  }, [infiniteCanvas]);
+
+  return { nodes, setNodes, redraw };
 };
+
+export default useNodes;


### PR DESCRIPTION
## Summary
- replace Pixi-based AppMap with `ef-infinite-canvas`
- render canvas grid and central red circle with automatic pan/zoom

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c128ffb7608325a7da7a558bfca2a0