### PR TITLE
Fix categorize containers API call and error handling

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -471,7 +471,8 @@ export const categorizeContainers = async (containerIds) => {
     try {
         console.log("Categorizing containers:", containerIds);
         const response = await apiClient.post(`${getApiUrl()}/categorize_containers`, {
-            "containers": containerIds,
+            // API expects `container_ids` for categorization
+            "container_ids": containerIds,
         });
         return response.data;
     } catch (error) {

--- a/src/hooks/flowContextMenu.js
+++ b/src/hooks/flowContextMenu.js
@@ -200,16 +200,19 @@ async function showChildren({ selectedNodes }) {
 async function categorize({ nodes, selectedNodes, activeGroup }) {
     let ids = selectedNodes.map(n => n.data.id);
     if (ids.length === 0) ids = nodes.map(n => n.data.id);
-    const ok = await api.categorizeContainers(ids);
-    alert(ok ? "Containers categorized successfully." : "Failed to categorize containers.");
-    console.log(ok.new_category_ids);
+    const result = await api.categorizeContainers(ids);
+    if (!result || !result.new_category_ids) {
+        alert("Failed to categorize containers.");
+        return;
+    }
+    alert("Containers categorized successfully.");
+    console.log(result.new_category_ids);
     if (!activeGroup) {
         requestRefreshChannel();
         return;
     }
-    ids = ok.new_category_ids;
     // add ids as children to the active group
-    await api.addChildren(activeGroup, ids);
+    await api.addChildren(activeGroup, result.new_category_ids);
     // brief delay to allow the request to complete
     requestRefreshChannel();
 }


### PR DESCRIPTION
## Summary
- send `container_ids` when categorizing containers
- handle failed categorization responses before proceeding

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6851dac78832581f47d0d86100815