### PR TITLE
Add instruction import UI to AppFlow

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -83,6 +83,17 @@ export const createContainer = async () => {
     }
 };
 
+// Apply a batch of instructions
+export const applyInstructionSet = async (instructionPayload) => {
+    try {
+        const response = await apiClient.post(`${getApiUrl()}/apply_instruction_set`, instructionPayload);
+        return response?.data;
+    } catch (error) {
+        console.error("Error applying instruction set:", error);
+        throw error;
+    }
+};
+
 
 // Get Mermaid json
 export const get_mermaid = async (rowId) => {


### PR DESCRIPTION
## Summary
- add api client helper for posting instruction batches to /apply_instruction_set
- add AppFlow controls to toggle an instruction import panel with paste and submit actions
- submit instructions as raw JSON and refresh flow state after applying

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f650b4380832594f9e1a026474ea5)